### PR TITLE
Tidy up calling structure

### DIFF
--- a/ConnectServo.cpp
+++ b/ConnectServo.cpp
@@ -18,8 +18,14 @@ ConnectServo::ConnectServo() : _servoQueue(sizeof(ServoQueueItem), QUEUE_SIZE_IT
 
 };
 
-void ConnectServo::enqueue(ServoQueueItem item) {
-  _servoQueue.push(&item);
+// void ConnectServo::enqueue(ServoQueueItem item) {
+//   _servoQueue.push(&item);
+// };
+
+void ConnectServo::enqueue(uint8_t newCall, uint8_t newParam1, uint8_t newAnimationType, uint16_t newServoSpeed) {
+    ServoQueueItem item;
+    item.assign(newCall, newParam1, newAnimationType, newServoSpeed);
+    _servoQueue.push(&item);
 };
 
 ServoQueueItem ConnectServo::dequeue() {

--- a/ConnectServo.h
+++ b/ConnectServo.h
@@ -36,7 +36,7 @@ class ServoQueueItem {
 class ConnectServo : public ServoEasing {
     public:
         ConnectServo();
-        void enqueue(ServoQueueItem item);
+        void enqueue(uint8_t, uint8_t, uint8_t, uint16_t);
         ServoQueueItem dequeue();
         bool update();
     private:

--- a/examples/servoObjectTest/servoObjectTest.ino
+++ b/examples/servoObjectTest/servoObjectTest.ino
@@ -20,34 +20,24 @@ void setup() {
     delay(500);
 
     // Queue some moves for the servo objects
-    myItem.assign(STARTEASETO, 180, EASE_CUBIC_IN_OUT, 30);
-    servo1.enqueue(myItem);
-    myItem.assign(WRITE, 0, 0, 0);
-    servo1.enqueue(myItem);
-    myItem.assign(STARTEASETO, 90, EASE_SINE_IN, 100);
-    servo1.enqueue(myItem);
-    myItem.assign(WRITE, 180, 0, 0);
-    servo1.enqueue(myItem);
-    myItem.assign(STARTEASETO, 0, EASE_SINE_OUT, 50);
-    servo1.enqueue(myItem);
+    servo1.enqueue(STARTEASETO, 180, EASE_CUBIC_IN_OUT, 30);
+    // servo1.enqueue(myItem);
+    servo1.enqueue(WRITE, 0, 0, 0);
+    servo1.enqueue(STARTEASETO, 90, EASE_SINE_IN, 100);
+    servo1.enqueue(WRITE, 180, 0, 0);
+    servo1.enqueue(STARTEASETO, 0, EASE_SINE_OUT, 50);
 
-    myItem.assign(STARTEASETO, 180, EASE_CUBIC_IN_OUT, 30);
-    servo2.enqueue(myItem);
-    myItem.assign(STARTEASETO, 0, EASE_CUBIC_IN_OUT, 150);
-    servo2.enqueue(myItem);
+    servo2.enqueue(STARTEASETO, 180, EASE_CUBIC_IN_OUT, 30);
+    servo2.enqueue(STARTEASETO, 0, EASE_CUBIC_IN_OUT, 150);
     // 3 wiggles
     // TODO: check if write actually works, or reports
     //       as finished after every dispatch.
     while (i < 3) {
-        myItem.assign(STARTEASETO, 180, EASE_LINEAR, 255);
-        servo2.enqueue(myItem);
-        myItem.assign(STARTEASETO, 0, EASE_LINEAR, 255);
-        servo2.enqueue(myItem);
+        servo2.enqueue(STARTEASETO, 180, EASE_LINEAR, 255);
+        servo2.enqueue(STARTEASETO, 0, EASE_LINEAR, 255);
         i++;
     }
-    myItem.assign(STARTEASETO, 180, EASE_CUBIC_IN_OUT, 20);
-    servo2.enqueue(myItem);
-
+    servo2.enqueue(STARTEASETO, 180, EASE_CUBIC_IN_OUT, 20);
 
 }
 


### PR DESCRIPTION
We're no longer passing objects, so can clean up the public API considerably. Should likely refactor from ServoQueueItem class to a simple struct.